### PR TITLE
Changed to Github URL for sitespeed.io so the GitHub stars will work

### DIFF
--- a/tools/monitoring/sitespeed.json
+++ b/tools/monitoring/sitespeed.json
@@ -1,5 +1,5 @@
 {
   "name" : "sitespeed.io",
-  "cli" : "http://www.sitespeed.io/",
+  "cli" : "https://github.com/sitespeedio/sitespeed.io",
   "description" : "Sitespeed.io is an open source tool that helps you analyze your website speed and performance based on performance best practices and metrics. It collects data from multiple pages on your website, analyze the pages using the rules and output the result as HTML or JUnit XML."
 }


### PR DESCRIPTION
Guess in the long run it would be nice to be able to configure multiple URL.s per project. 
