### PR TITLE
bugfix on the footer

### DIFF
--- a/less/layout/_footer.less
+++ b/less/layout/_footer.less
@@ -41,6 +41,7 @@
 
   .copyright {
     float: right;
+    padding-top: 0.2em;
   }
 
 }


### PR DESCRIPTION
This minor bugfix vertically centers the Copyright information when the site is seen on a larger viewport.
