### PR TITLE
Update links to sharp-based gulp/grunt tools

### DIFF
--- a/data/tools/sharp.json
+++ b/data/tools/sharp.json
@@ -1,7 +1,8 @@
 {
 "name" : "sharp",
 "description" : "The typical use case for this high speed Node.js module is to convert large images of many formats to smaller, web-friendly JPEG, PNG and WebP images of varying dimensions.",
-"gulp": "https://github.com/rizalp/gulp-sharp",
+"grunt": "https://github.com/unindented/grunt-sharp",
+"gulp": "https://github.com/mahnunchik/gulp-responsive",
 "module" : "https://github.com/lovell/sharp",
 "tags" : [ "compression", "images" ]
 }


### PR DESCRIPTION
Hi, I'm the maintainer of sharp - thanks for adding it to perf-tooling in the first place!

I've added a grunt plugin and updated the gulp plugin to point to a slightly better maintained repo.

Ideally this could link to both gulp plugins but I'm not sure there's a way to do that right now.

Cheers,
Lovell