### PR TITLE
adds flood.io service

### DIFF
--- a/data/tools/flood-io.json
+++ b/data/tools/flood-io.json
@@ -2,5 +2,5 @@
   "name" : "Flood IO",
   "service" : "https://flood.io",
   "description" : "Flood IO lets you run distributed load tests across the globe with JMeter or Gatling. Use our On Demand infrastructure or Host Your Own cloud.",
-  "tags" : [ "load testing" ]
+  "tags" : [ "load", "testing" ]
 }

--- a/data/tools/flood-io.json
+++ b/data/tools/flood-io.json
@@ -1,0 +1,6 @@
+{
+  "name" : "Flood IO",
+  "service" : "https://flood.io",
+  "description" : "'Flood IO lets you run distributed load tests across the globe with JMeter or Gatling. Use our On Demand infrastructure or Host Your Own cloud.",
+  "tags" : [ "load testing" ]
+}

--- a/data/tools/flood-io.json
+++ b/data/tools/flood-io.json
@@ -1,6 +1,6 @@
 {
   "name" : "Flood IO",
   "service" : "https://flood.io",
-  "description" : "'Flood IO lets you run distributed load tests across the globe with JMeter or Gatling. Use our On Demand infrastructure or Host Your Own cloud.",
+  "description" : "Flood IO lets you run distributed load tests across the globe with JMeter or Gatling. Use our On Demand infrastructure or Host Your Own cloud.",
   "tags" : [ "load testing" ]
 }


### PR DESCRIPTION
Flood IO lets you run distributed load tests across the globe with JMeter or Gatling.