### PR TITLE
Feature/181 add browsersync

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ We would like this project to become a shared resource maintained by the communi
 
 Perf Tooling is an [express](http://expressjs.com/) application. If you want to see it in action simply clone the repository and run `npm install`.
 
-After that you can start the server with:
+After that you can start the server and kick of the development environment with:
 
 ```
-node app.js
+npm start
 ```
+This will start the express application at `localhost:3000`.
 
-It will be available at `localhost:3000`.
+In case you want to develop new things at `localhost:4000` will be a proxy injecting [browsersync.io](http://browsersync.io) which means that the page will automagically refresh whenever you change something. Using `npm start` all watchers will be set up listening for the following:
+
+- `js/**/*.js` -> generating new built JS + restart express server + browser reload
+- `less/**/*.less` -> generating new built CSS + restart express server + browser reload
+- `templates/**/*.tpl` -> restart express server + browser reload
+- `app.js` -> restart express server + browser reload
+
 Be aware of the fact, that the fetching of Github stars may not work, because Github is limiting the number of requests that are allowed without any authorization.
+

--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ if (
 }
 
 
-var port         = process.env.PORT || 3000;
+var port         = process.env.PORT || config.port;
 
 
 var data         = {

--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  port      : 3000,
   cdn       : process.env.CDN_URL || '',
   dataDir   : 'data',
   listPages : [ 'articles', 'slides', 'tools', 'videos', 'books' ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,8 +94,7 @@ gulp.task( 'scripts', function() {
   return gulp.src( files.scripts )
     .pipe( concat( 'tooling.js' ) )
     .pipe( uglify() )
-    .pipe( gulp.dest( 'public' ) )
-    .pipe( reload( { stream : true } ) );
+    .pipe( gulp.dest( 'public' ) );
 } );
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,7 +150,7 @@ gulp.task( 'browser-sync', [ 'nodemon' ], function() {
  *
  * this task is responsible for setting nodemon and the express application
  */
-gulp.task( 'nodemon', function (cb) {
+gulp.task( 'nodemon', [ 'build' ], function (cb) {
   var called = false;
 
   nodemon( {
@@ -160,7 +160,7 @@ gulp.task( 'nodemon', function (cb) {
   } ).on( 'start', function () {
     if ( !called ) {
       called = true;
-      cb();
+      setTimeout( cb, 1000 );
     }
   } ).on( 'restart', function() {
     browserSync.reload();
@@ -183,7 +183,7 @@ gulp.task( 'build', [ 'styles', 'scripts', 'svg', 'images' ] );
  * this task will kick off the watcher for JS, CSS, HTML files
  * for easy and instant development
  */
-gulp.task( 'watch', [ 'browser-sync' ], function() {
+gulp.task( 'dev', [ 'browser-sync' ], function() {
   gulp.watch( files.lint, [ 'lint' ] );
   gulp.watch( files.watch.styles, [ 'styles' ] );
   gulp.watch( files.scripts, [ 'scripts' ] );
@@ -199,7 +199,7 @@ gulp.task( 'watch', [ 'browser-sync' ], function() {
  * $ gulp dev
  *
  */
-gulp.task( 'dev', [ 'build', 'watch' ] );
+// gulp.task( 'dev', [ 'build' ] );
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
   "engines": {
     "node": "0.10.x"
   },
+  "scripts": {
+    "gulp" : "gulp",
+    "start": "gulp dev",
+    "watch": "gulp watch"
+  },
   "author": "stefan judis <stefanjudis@gmail.com>",
   "license": "MIT",
   "bugs": {
@@ -20,6 +25,7 @@
   "homepage": "http://perf-tooling.today",
   "dependencies": {
     "MD5": "^1.2.1",
+    "browser-sync": "^2.3.1",
     "compression": "^1.1.0",
     "express": "^4.9.0",
     "gulp": "~3.8.0",
@@ -28,7 +34,7 @@
     "gulp-csslint": "^0.1.5",
     "gulp-imagemin": "^2.1.0",
     "gulp-jshint": "^1.9.0",
-    "gulp-less": "~2.0.1",
+    "gulp-less": "^3.0.0",
     "gulp-minify-css": "~0.3.0",
     "gulp-svgstore": "~4.0.1",
     "gulp-task-listing": "^1.0.0",
@@ -39,6 +45,7 @@
     "imagemin-pngquant": "^4.0.0",
     "jshint-stylish": "^1.0.0",
     "lodash": "^2.4.1",
+    "nodemon": "^1.3.7",
     "request": "^2.44.0",
     "twit": "^1.1.18",
     "vimeo-api": "^1.1.1",


### PR DESCRIPTION
Allright - browsersync landed.

Everything can now be started by `npm start`. :)

One thing to mention. I had to put in a delay because whenever we change something in the assets the express server has to be restarted. Played around with it a bit and set it to 1sec now.

It's reacting to changes in templates, less and JS files. :)

Let me know what you think of that.

@marcobiedermann @radibit @marhigh 