### PR TITLE
Adding Paul Irish keynote from Fluent 2015 to videos

### DIFF
--- a/data/videos/how-users-perceive-the-speed-of-the-web.json
+++ b/data/videos/how-users-perceive-the-speed-of-the-web.json
@@ -1,0 +1,11 @@
+{
+  "name" : "How Users Perceive the Speed of The Web - Paul Irish (Google) keynote",
+  "authors" : [
+    {
+      "name" : "Paul Irish",
+      "twitter" : "@paul_irish"
+    }
+  ],
+  "youtubeId" : "2ksXo2_Lfl0",
+  "tags" : [ "devtools", "UX" ]
+}

--- a/data/videos/how-users-perceive-the-speed-of-the-web.json
+++ b/data/videos/how-users-perceive-the-speed-of-the-web.json
@@ -7,5 +7,5 @@
     }
   ],
   "youtubeId" : "2ksXo2_Lfl0",
-  "tags" : [ "devtools", "UX" ]
+  "tags" : [ "devtools", "UX", "metrics" ]
 }


### PR DESCRIPTION
Paul explains the RAIL model for judging performance from a users perspective and give some recommendations for the maximum time that the four different interaction times should take. His demo fails at the end due to poor conference wifi (a bit ironic for a performance talk) but he shows the new filmstrip view on the networks tab available in chrome canary.