### PR TITLE
Adding Httpq as a tool (resolves #634)

### DIFF
--- a/data/tools/httpq.json
+++ b/data/tools/httpq.json
@@ -1,0 +1,6 @@
+{
+  "name" : "Httpq",
+  "cli" : "https://github.com/DavidHuie/httpq",
+  "description" : "A Go service for buffering HTTP requests and processing them asynchronously",
+  "tags" : [ "http", "webhooks", "buffers" ]
+}


### PR DESCRIPTION
Httpq is a service for buffering HTTP requests and processing them
asynchronously.

@marcobiedermann