### PR TITLE
fix #1084 - add PerfMap browser extension

### DIFF
--- a/data/tools/perf-map.json
+++ b/data/tools/perf-map.json
@@ -3,6 +3,9 @@
   "bookmarklet" : {
     "url" : "https://github.com/zeman/perfmap"
   },
-  "description" : "A bookmarklet to create a front-end performance heatmap of resources loaded in the browser using the Resource Timing API.",
+  "chrome": {
+    "url": "https://chrome.google.com/webstore/detail/perfmap/hgpnhiajcdppfbogcpfdgcceepgkhdmk"
+  },
+  "description" : "A bookmarklet and Chrome extension to create a front-end performance heatmap of resources loaded in the browser using the Resource Timing API.",
   "tags" : [ "timings" ]
 }


### PR DESCRIPTION
Performance-Analyser is already listed: https://github.com/stefanjudis/perf-tooling/blob/master/data/tools/performance-bookmarklet.json#L6