### PR TITLE
Update "Load Impact" in tools

### DIFF
--- a/data/tools/HTTP-1-vs-HTTP-2-by-LoadImpact.json
+++ b/data/tools/HTTP-1-vs-HTTP-2-by-LoadImpact.json
@@ -1,8 +1,0 @@
-{
-  "name" : "HTTP/1 vs HTTP/2 by LoadImpact",
-  "service" : {
-    "url" : "http://http2.loadimpact.com/entry/"
-  },
-  "description" : "Loadimpact gathers all resources from your URL, fetches those resources from their own server using HTTP/2 and give you some neat stats on how load times would differ between the two protocols.",
-  "tags" : [ "network", "http", "metrics" ]
-}

--- a/data/tools/loadimpact.json
+++ b/data/tools/loadimpact.json
@@ -1,0 +1,9 @@
+{
+  "name" : "Load Impact",
+  "service" : {
+    "url" : "https://loadimpact.com/",
+    "isPaid": true
+  },
+  "description" : "Performance and load testing for Apps and APIs. 1 test for free without account. 5 free tests a month after registration. With the paid version, With Load Impact, you can create a load test which simulates different browsers, network conditions and visitor behaviors.",
+  "tags": ["metrics", "load", "timings"]
+}


### PR DESCRIPTION
The link no longer works. I could only find announcement-websites (https://loadimpact.com/http2-vs-http1.1-performance, https://loadimpact.com/http2old) but not the tool itself.